### PR TITLE
Preserve original log timestamps when archiving

### DIFF
--- a/Scripts_LLM_trader/archive_llm_results.py
+++ b/Scripts_LLM_trader/archive_llm_results.py
@@ -34,6 +34,10 @@ for filename in os.listdir(LLM_data_path):
             with open(dest_file, "a") as df, open(file_full_path, "r") as sf:
                 shutil.copyfileobj(sf, df)
 
+            # Carry the original file's timestamps over to the archived copy
+            src_stat = os.stat(file_full_path)
+            os.utime(dest_file, (src_stat.st_atime, src_stat.st_mtime))
+
             # Remove original file
             os.remove(file_full_path)
             print(f"Appended and removed {file_full_path} -> {dest_file}")

--- a/archive_here.sh
+++ b/archive_here.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "Starting Log Archive"
+TODAYS_DATE=$(date +%Y%m%d)
+ARCHIVE_PATH="$LOG_DIR/archive/$TODAYS_DATE"
+
+mkdir -p "$ARCHIVE_PATH"
+
+EXCLUDE_LIST=("archive_here.sh" "archive")
+
+for FILE_FULL_PATH in "$LOG_DIR"/*; do
+    FILENAME=$(basename "$FILE_FULL_PATH")
+    if [[ ! " ${EXCLUDE_LIST[@]} " =~ " ${FILENAME} " ]]; then
+        [ -f "$FILE_FULL_PATH" ] || continue
+        # append, carry the original mtime over to the archived copy,
+        # and only delete the source once both steps succeeded
+        cat "$FILE_FULL_PATH" >> "$ARCHIVE_PATH/$FILENAME" \
+            && touch -r "$FILE_FULL_PATH" "$ARCHIVE_PATH/$FILENAME" \
+            && rm "$FILE_FULL_PATH" \
+            && echo "Appended and removed $FILE_FULL_PATH to $ARCHIVE_PATH/$FILENAME"
+    fi
+done
+
+echo "Archive Finished $TODAYS_DATE"


### PR DESCRIPTION
cat+rm was resetting the archived file's mtime to the time the archive ran. Copy the source file's timestamps onto the archived copy before deleting (touch -r in archive_here.sh, os.utime in the Python port), and only delete the source once the append succeeded.


Claude-Session: https://claude.ai/code/session_01LCJFuWT3nSVPAb48Fxa6hz